### PR TITLE
Don’t use a leading forward slash in topics

### DIFF
--- a/mqtt-gpio-monitor.ini.example
+++ b/mqtt-gpio-monitor.ini.example
@@ -8,8 +8,8 @@ MQTT_CLIENT_ID     = mqtt-gpio-monitor
 MQTT_QOS           = 2
 MQTT_RETAIN        = False
 MQTT_CLEAN_SESSION = True
-MQTT_TOPIC         = /mqtt-gpio-monitor
-MQTT_LWT           = /clients/mqtt-gpio-monitor
+MQTT_TOPIC         = mqtt-gpio-monitor
+MQTT_LWT           = clients/mqtt-gpio-monitor
 
 # authentication (optional)
 MQTT_USERNAME      = 
@@ -26,4 +26,4 @@ MONITOR_PINS_PUD   = UP
 MONITOR_PIN_NUMBERING = BOARD
 MONITOR_OUT_INVERT = False
 MONITOR_POLL       = 0.1
-MONITOR_REFRESH    = /mqtt-gpio-monitor/refresh
+MONITOR_REFRESH    = mqtt-gpio-monitor/refresh


### PR DESCRIPTION
According to MQTT Topics & Best Practices, e.g. https://www.hivemq.com/blog/mqtt-essentials-part-5-mqtt-topics-best-practices, topics should not begin with a slash. Could you please change the ini.example? It relates to MQTT_TOPIC, MQTT_LWT and MONITOR_REFRESH.